### PR TITLE
feat(nightly): use commit count instead of commit hash

### DIFF
--- a/.github/workflows/nightly-builder.yml
+++ b/.github/workflows/nightly-builder.yml
@@ -24,7 +24,7 @@ jobs:
     uses: ./.github/workflows/build-Linux.yml
     secrets: inherit
     with: 
-      versionName: ${{ needs.check.outputs.latestSHA }}
+      versionName: ${{ needs.check.outputs.tagName }}
       buildType: 'nightly'
 
   mac-builder:
@@ -35,7 +35,7 @@ jobs:
     uses: ./.github/workflows/build-Mac.yml
     secrets: inherit
     with: 
-      versionName: ${{ needs.check.outputs.latestSHA }}
+      versionName: ${{ needs.check.outputs.tagName }}
       buildType: 'nightly'
 
   windows-builder:
@@ -46,7 +46,7 @@ jobs:
     uses: ./.github/workflows/build-Windows.yml
     secrets: inherit
     with: 
-      versionName: ${{ needs.check.outputs.latestSHA }}
+      versionName: ${{ needs.check.outputs.tagName }}
       buildType: 'nightly'
 
   publish:
@@ -64,7 +64,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          release_name: Nightly Build - ${{ needs.check.outputs.latestSHA }}
+          release_name: Nightly Build - ${{ needs.check.outputs.tagName }}
           tag: ${{ needs.check.outputs.tagName }}
           file: builds/*
           file_glob: true

--- a/methods/CheckLatestRelease.js
+++ b/methods/CheckLatestRelease.js
@@ -4,7 +4,7 @@ import * as core from '@actions/core';
 
 const latestRelease = await GetLatestRelease(BLEEDINGEDGE_REPOSITORYAUTHOR, BLEEDINGEDGE_REPOSITORYNAME);
 const devCommits = await GetCommits(YARG_ORGANIZATIONNAME, YARG_GAMEREPOSITORY, YARG_DEVBRANCH, latestRelease.published_at);
-const latestDevCommit = devCommits[0];
+const latestDevCommit = devCommits.commits[0];
 const nightlyVersionName = `b${devCommits?.branchCommitCount}`;
 
 function checkReleasePlatformBuild(release, platform = process.env.PLATFORM) {

--- a/methods/CheckLatestRelease.js
+++ b/methods/CheckLatestRelease.js
@@ -7,7 +7,7 @@ const devCommits = await GetCommits(YARG_ORGANIZATIONNAME, YARG_GAMEREPOSITORY, 
 const latestDevCommit = devCommits[0];
 const nightlyVersionName = `b${devCommits?.branchCommitCount}`;
 
-function FindIfLastestCommitHasBuild(release, platform = process.env.PLATFORM) {
+function checkReleasePlatformBuild(release, platform = process.env.PLATFORM) {
     const assetName = `YARG_${nightlyVersionName}-${platform}`;
 
     const index = release.assets.findIndex(asset => 
@@ -19,9 +19,9 @@ function FindIfLastestCommitHasBuild(release, platform = process.env.PLATFORM) {
     return index >= 0;
 }
 
-core.setOutput("macBuild", !FindIfLastestCommitHasBuild(latestRelease, "MacOS"));
-core.setOutput("windowsBuild", !FindIfLastestCommitHasBuild(latestRelease, "Windows"));
-core.setOutput("linuxBuild", !FindIfLastestCommitHasBuild(latestRelease, "Linux"));
+core.setOutput("macBuild", !checkReleasePlatformBuild(latestRelease, "MacOS"));
+core.setOutput("windowsBuild", !checkReleasePlatformBuild(latestRelease, "Windows"));
+core.setOutput("linuxBuild", !checkReleasePlatformBuild(latestRelease, "Linux"));
 
 /**
  * Takes all messages from commits and format them to the release message body;

--- a/methods/CheckLatestRelease.js
+++ b/methods/CheckLatestRelease.js
@@ -3,8 +3,8 @@ import { BLEEDINGEDGE_REPOSITORYAUTHOR, BLEEDINGEDGE_REPOSITORYNAME, YARG_DEVBRA
 import * as core from '@actions/core';
 
 const latestRelease = await GetLatestRelease(BLEEDINGEDGE_REPOSITORYAUTHOR, BLEEDINGEDGE_REPOSITORYNAME);
-const latestDevCommit = await GetLatestCommit(YARG_ORGANIZATIONNAME, YARG_GAMEREPOSITORY, YARG_DEVBRANCH);
 const devCommits = await GetCommits(YARG_ORGANIZATIONNAME, YARG_GAMEREPOSITORY, YARG_DEVBRANCH, latestRelease.published_at);
+const latestDevCommit = devCommits[0];
 const nightlyVersionName = `b${devCommits?.branchCommitCount}`;
 
 function FindIfLastestCommitHasBuild(release, platform = process.env.PLATFORM) {
@@ -34,7 +34,7 @@ function formatMessages(devCommits) {
 };
 
 const messageBody = 
-`Built using the commit https://github.com/${YARG_ORGANIZATIONNAME}/${YARG_GAMEREPOSITORY}/commit/${latestDevCommit.sha}
+`Built using the commit https://github.com/${YARG_ORGANIZATIONNAME}/${YARG_GAMEREPOSITORY}/commit/${latestDevCommit?.oid}
 
 
 ### ⚠️ This build is an extremely early beta, so bugs are expected. ⚠️
@@ -48,6 +48,6 @@ Downloads are below.
 ${formatMessages(devCommits.commits)}
 `;
 
-core.setOutput("messageBody", devCommits.length > 0 ? messageBody : latestRelease.body);
-core.setOutput("latestSHA", latestDevCommit.sha);
+core.setOutput("messageBody", devCommits.commits.length > 0 ? messageBody : latestRelease.body);
+core.setOutput("latestSHA", latestDevCommit?.oid);
 core.setOutput("tagName", nightlyVersionName);

--- a/methods/CheckLatestRelease.js
+++ b/methods/CheckLatestRelease.js
@@ -5,10 +5,10 @@ import * as core from '@actions/core';
 const latestRelease = await GetLatestRelease(BLEEDINGEDGE_REPOSITORYAUTHOR, BLEEDINGEDGE_REPOSITORYNAME);
 const latestDevCommit = await GetLatestCommit(YARG_ORGANIZATIONNAME, YARG_GAMEREPOSITORY, YARG_DEVBRANCH);
 const devCommits = await GetCommits(YARG_ORGANIZATIONNAME, YARG_GAMEREPOSITORY, YARG_DEVBRANCH, latestRelease.published_at);
+const nightlyVersionName = `b${devCommits?.branchCommitCount}`;
 
 function FindIfLastestCommitHasBuild(release, platform = process.env.PLATFORM) {
-    const sha = latestDevCommit.sha;
-    const assetName = `YARG_${sha}-${platform}`;
+    const assetName = `YARG_${nightlyVersionName}-${platform}`;
 
     const index = release.assets.findIndex(asset => 
         asset.name
@@ -45,9 +45,9 @@ Downloads are below.
 
 ## 📋 Commits
 
-${formatMessages(devCommits)}
+${formatMessages(devCommits.commits)}
 `;
 
 core.setOutput("messageBody", devCommits.length > 0 ? messageBody : latestRelease.body);
 core.setOutput("latestSHA", latestDevCommit.sha);
-core.setOutput("tagName", latestDevCommit.sha.substring(0, 7));
+core.setOutput("tagName", nightlyVersionName);

--- a/utils/Github.js
+++ b/utils/Github.js
@@ -52,16 +52,19 @@ export async function GetCommits(repositoryAuthor, repositoryName, branch, since
                 ref(qualifiedName:$branch) {
                 target {
                 ... on Commit {
+                    branchCommitCount: history(first: 0) {
+                        totalCount
+                    },
                     history(first: 100, since:$since) {
-                    nodes {
-                        oid,
-                        author {
-                            user {
-                                login
-                            }
-                        },
-                        messageHeadline
-                    }
+                        nodes {
+                            oid,
+                            author {
+                                user {
+                                    login
+                                }
+                            },
+                            messageHeadline
+                        }
                     }
                 }
                 }
@@ -75,7 +78,10 @@ export async function GetCommits(repositoryAuthor, repositoryName, branch, since
         since
     });
 
-    return data.repository.ref.target.history.nodes;
+    return {
+        branchCommitCount: data.repository.ref.target.branchCommitCount.totalCount,
+        commits: data.repository.ref.target.history.nodes
+    };
 }
 
 /**

--- a/utils/const.js
+++ b/utils/const.js
@@ -1,8 +1,8 @@
 export const GITHUB_API_ROOT = "https://api.github.com/";
 
-export const YARG_ORGANIZATIONNAME = process.env.REPOSITORY_AUTHOR;
-export const YARG_GAMEREPOSITORY = process.env.REPOSITORY_NAME;
-export const YARG_DEVBRANCH = process.env.REPOSITORY_BRANCH;
+export const YARG_ORGANIZATIONNAME = process.env.REPOSITORY_AUTHOR || "YARC-Official";
+export const YARG_GAMEREPOSITORY = process.env.REPOSITORY_NAME || "YARG";
+export const YARG_DEVBRANCH = process.env.REPOSITORY_BRANCH || "dev";
 
 export const BLEEDINGEDGE_REPOSITORYAUTHOR = process.env.BLEEDINGEDGE_REPOSITORYAUTHOR || YARG_ORGANIZATIONNAME || "YARC-Official";
 export const BLEEDINGEDGE_REPOSITORYNAME = process.env.BLEEDINGEDGE_REPOSITORYNAME || "YARG-BleedingEdge";


### PR DESCRIPTION
**Summary:**
This changes the `version name` and `tag name` from nightly builds to use the amount of commits from the `dev` branch instead of the commit hash from the last dev commit.

**Example:**
`3caedda` (old) -> `b2089` (new)