### PR TITLE
build: update unity version to 2021.3.36f1

### DIFF
--- a/.github/workflows/build-Linux.yml
+++ b/.github/workflows/build-Linux.yml
@@ -53,8 +53,8 @@ on:
 env:
   platform: "Linux"
 
-  unityVersion: "2021.3.21f1"
-  unityVersionHash: "1b156197d683"
+  unityVersion: "2021.3.36f1"
+  unityVersionHash: "7a0645017be0"
   blenderMajorVersion: "3.4"
   blenderVersion: "3.4.1"
 
@@ -75,7 +75,6 @@ jobs:
     timeout-minutes: 90
 
     steps:
-
       #############################
       #       Install Unity       #
       #############################
@@ -109,7 +108,6 @@ jobs:
           tar -xvf "${{ runner.temp }}/UnityInstall/UnitySetup-Linux-IL2CPP-Support.tar.xz" -C "${{ runner.temp }}/Unity" &&
           rm -rf "${{ runner.temp }}/UnityInstall"
 
-
       #############################
       #          Checkout         #
       #############################
@@ -138,7 +136,6 @@ jobs:
           repository: ${{ github.repository }}
           path: bleedingedge
 
-
       #############################
       #           Cache           #
       #############################
@@ -148,7 +145,6 @@ jobs:
         with:
           path: Library
           key: ${{ env.platform }}-YARG_Library
-
 
       #############################
       #  Add Nightly definition   #
@@ -167,7 +163,7 @@ jobs:
       - name: "[Pre-install] Get Blender (${{ env.blenderVersion }}) from cache"
         id: blender
         uses: actions/cache@v3
-        with: 
+        with:
           path: ${{ runner.temp }}/BlenderInstall
           key: Linux_Blender-${{ env.blenderVersion }}
           restore-keys: Linux_Blender-
@@ -183,7 +179,6 @@ jobs:
           sudo mv /opt/blender*/ /opt/blender &&
           sudo ln -sf /opt/blender/blender /usr/bin/blender
 
-
       #############################
       #     Restore  Packages     #
       #############################
@@ -191,11 +186,10 @@ jobs:
       - name: "[Pre-install] Install dotnet 8.x"
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: "8.0.x"
 
       - name: "[Pre-install] Restoring NuGet Packages"
         run: dotnet tool install --global NuGetForUnity.Cli && nugetforunity restore
-
 
       #############################
       #       Replace icon        #
@@ -209,7 +203,6 @@ jobs:
         name: "[Pre-build] Replace icon with Nightly"
         run: "cp -f bleedingedge/static/Icon_Nightly.png Assets/Art/UI/Icon_Stable.png"
 
-
       #############################
       #      Build YARG.Core      #
       #############################
@@ -218,7 +211,6 @@ jobs:
         run: >
           mkdir Assets/Plugins/YARG.Core &&
           dotnet build YARG.Core/YARG.Core/YARG.Core.csproj /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary --output Assets/Plugins/YARG.Core
-
 
       #############################
       #           Build           #
@@ -235,13 +227,11 @@ jobs:
         continue-on-error: true
         run: ${{ runner.temp }}/Unity/Editor/Unity -quit -batchmode -nographics -returnlicense -projectPath ${{ github.workspace }} -username ${{ secrets.LINUX_UNITY_EMAIL || secrets.UNITY_EMAIL }} -password ${{ secrets.LINUX_UNITY_PASSWORD || secrets.UNITY_PASSWORD }} -logfile -
 
-
       #############################
       #         Compress          #
       #############################
       - name: "[Post-build] Compress to a .zip"
         run: mkdir Release && (cd build && zip -r ../Release/YARG_${{ env.versionName }}-Linux-x64.zip .)
-
 
       #############################
       #          Upload           #
@@ -253,5 +243,5 @@ jobs:
           name: YARG (${{ env.versionName }}) - ${{ env.platform }}
           path: Release/*
 
-    outputs: 
+    outputs:
       artifactId: ${{ steps.artifacts.outputs.artifact-id }}

--- a/.github/workflows/build-Mac.yml
+++ b/.github/workflows/build-Mac.yml
@@ -53,8 +53,8 @@ on:
 env:
   platform: "MacOS"
 
-  unityVersion: "2021.3.21f1"
-  unityVersionHash: "1b156197d683"
+  unityVersion: "2021.3.36f1"
+  unityVersionHash: "7a0645017be0"
   blenderMajorVersion: "3.4"
   blenderVersion: "3.4.1"
 
@@ -75,7 +75,6 @@ jobs:
     timeout-minutes: 90
 
     steps:
-
       #############################
       #          Checkout         #
       #############################
@@ -104,7 +103,6 @@ jobs:
           repository: ${{ github.repository }}
           path: bleedingedge
 
-
       #############################
       #           Cache           #
       #############################
@@ -114,7 +112,6 @@ jobs:
         with:
           path: Library
           key: ${{ env.platform }}-YARG_Library
-
 
       #############################
       #  Add Nightly definition   #
@@ -133,7 +130,7 @@ jobs:
       - name: "[Pre-install] Get Blender (${{ env.blenderVersion }}) from cache"
         id: blender
         uses: actions/cache@v3
-        with: 
+        with:
           path: ${{ runner.temp }}/BlenderInstall
           key: Mac_Blender-${{ env.blenderVersion }}
           restore-keys: Mac_Blender-
@@ -148,7 +145,6 @@ jobs:
           hdiutil attach ${{ runner.temp }}/BlenderInstall/blender.dmg && 
           cp -R /Volumes/Blender/Blender.app /Applications && 
           hdiutil unmount /Volumes/Blender
-        
 
       #############################
       #     Restore  Packages     #
@@ -157,11 +153,10 @@ jobs:
       - name: "[Pre-install] Install dotnet 8.x"
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: "8.0.x"
 
       - name: "[Pre-install] Restoring NuGet Packages"
         run: dotnet tool install --global NuGetForUnity.Cli && nugetforunity restore
-
 
       #############################
       #       Replace icon        #
@@ -175,7 +170,6 @@ jobs:
         name: "[Pre-build] Replace icon with Nightly"
         run: "cp -f bleedingedge/static/Icon_Nightly.png Assets/Art/UI/Icon_Stable.png"
 
-
       #############################
       #      Build YARG.Core      #
       #############################
@@ -185,7 +179,6 @@ jobs:
           mkdir Assets/Plugins/YARG.Core &&
           dotnet build YARG.Core/YARG.Core/YARG.Core.csproj /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary --output Assets/Plugins/YARG.Core
 
-
       #############################
       #           Build           #
       #############################
@@ -194,7 +187,7 @@ jobs:
         run: |
           mkdir ${{ runner.temp }}/UnityInstall &&
           curl -L -o "${{ runner.temp }}/UnityInstall/UnitySetup-Editor.pkg" https://download.unity3d.com/download_unity/${{ env.unityVersionHash }}/MacEditorInstaller/Unity-${{ env.unityVersion }}.pkg &&
-          curl -L -o "${{ runner.temp }}/UnityInstall/UnitySetup-Mac-IL2CPP-Support.pkg" https://download.unity3d.com/download_unity/${{ env.unityVersionHash }}/MacEditorTargetInstaller/UnitySetup-Mac-IL2CPP-Support-for-Editor-${{ env.unityVersion }}.pkg        
+          curl -L -o "${{ runner.temp }}/UnityInstall/UnitySetup-Mac-IL2CPP-Support.pkg" https://download.unity3d.com/download_unity/${{ env.unityVersionHash }}/MacEditorTargetInstaller/UnitySetup-Mac-IL2CPP-Support-for-Editor-${{ env.unityVersion }}.pkg
 
       - name: "[Install] Install Unity Editor + Mac IL2CPP builder"
         run: |
@@ -210,14 +203,12 @@ jobs:
         continue-on-error: true
         run: /Applications/Unity/Unity.app/Contents/MacOS/Unity -quit -batchmode -nographics -returnlicense -projectPath ${{ github.workspace }} -username ${{ secrets.MAC_UNITY_EMAIL || secrets.UNITY_EMAIL }} -password ${{ secrets.MAC_UNITY_PASSWORD || secrets.UNITY_PASSWORD }} -logfile -
 
-
       #############################
       #         Compress          #
       #############################
 
       - name: "[Post-build] Compress to a .zip"
         run: ditto -c -k --keepParent build/YARG.app Release/YARG_${{ env.versionName }}-MacOS-Universal.zip
-        
 
       #############################
       #          Upload           #
@@ -230,5 +221,5 @@ jobs:
           name: YARG (${{ env.versionName }}) - ${{ env.platform }}
           path: Release/*
 
-    outputs: 
+    outputs:
       artifactId: ${{ steps.artifacts.outputs.artifact-id }}

--- a/.github/workflows/build-Windows.yml
+++ b/.github/workflows/build-Windows.yml
@@ -53,8 +53,8 @@ on:
 env:
   platform: "Windows"
 
-  unityVersion: "2021.3.21f1"
-  unityVersionHash: "1b156197d683"
+  unityVersion: "2021.3.36f1"
+  unityVersionHash: "7a0645017be0"
   blenderMajorVersion: "3.5"
   blenderVersion: "3.5.1"
 
@@ -75,7 +75,6 @@ jobs:
     timeout-minutes: 90
 
     steps:
-
       #############################
       #       Install Unity       #
       #############################
@@ -83,7 +82,7 @@ jobs:
       - name: "[Install] Get Unity Editor + Windows IL2CPP builder (${{ env.unityVersion }}) pre-installed from cache"
         id: unity-install
         uses: actions/cache@v3.2.2
-        with: 
+        with:
           path: ${{ runner.temp }}/Unity
           key: Windows_Unity-${{ env.unityVersion }}
 
@@ -102,7 +101,6 @@ jobs:
           Start-Process "${{ runner.temp }}\UnityInstall\UnitySetup64-${{ env.unityVersion }}.exe" -ArgumentList $UNITY_INSTALLARGUMENTS -wait -nonewwindow;
           Start-Process "${{ runner.temp }}\UnityInstall\UnitySetup-Windows-IL2CPP-Support-for-Editor-${{ env.unityVersion }}.exe" -ArgumentList $UNITY_INSTALLARGUMENTS -wait -nonewwindow;
           Remove-Item -Recurse -Force -Path ${{ runner.temp }}\UnityInstall\*;
-
 
       #############################
       #          Checkout         #
@@ -132,7 +130,6 @@ jobs:
           repository: ${{ github.repository }}
           path: bleedingedge
 
-
       #############################
       #           Cache           #
       #############################
@@ -142,7 +139,6 @@ jobs:
         with:
           path: Library
           key: ${{ env.platform }}-YARG_Library
-
 
       #############################
       #  Add Nightly definition   #
@@ -161,7 +157,7 @@ jobs:
       - name: "[Pre-install] Get Blender (${{ env.blenderVersion }}) from cache"
         id: blender
         uses: actions/cache@v3
-        with: 
+        with:
           path: ${{ runner.temp }}/BlenderInstall
           key: Windows_Blender-${{ env.blenderVersion }}
           restore-keys: Windows_Blender-
@@ -177,7 +173,6 @@ jobs:
           $BLENDERARGS = "/I $BLENDERMSI ALLUSERS=1 /qn /norestart";
           Start-Process "msiexec.exe" -ArgumentList $BLENDERARGS -wait -nonewwindow
 
-
       #############################
       #     Restore  Packages     #
       #############################
@@ -185,11 +180,10 @@ jobs:
       - name: "[Pre-install] Install dotnet 8.x"
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: "8.0.x"
 
       - name: "[Pre-install] Restoring NuGet Packages"
         run: dotnet tool install --global NuGetForUnity.Cli && nugetforunity restore
-
 
       #############################
       #      Build YARG.Core      #
@@ -199,7 +193,6 @@ jobs:
         run: >
           mkdir Assets/Plugins/YARG.Core;
           dotnet build YARG.Core/YARG.Core/YARG.Core.csproj /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary --output Assets/Plugins/YARG.Core;
-
 
       #############################
       #       Replace icon        #
@@ -215,7 +208,6 @@ jobs:
         shell: bash
         run: "cp -f bleedingedge/static/Icon_Nightly.png Assets/Art/UI/Icon_Stable.png"
 
-
       #############################
       #           Build           #
       #############################
@@ -230,7 +222,6 @@ jobs:
         continue-on-error: true
         run: ${{ runner.temp }}/Unity/Editor/Unity.exe -quit -batchmode -nographics -returnlicense -projectPath ${{ github.workspace }} -username ${{ secrets.WINDOWS_UNITY_EMAIL || secrets.UNITY_EMAIL }} -password ${{ secrets.WINDOWS_UNITY_PASSWORD || secrets.UNITY_PASSWORD }} -logfile | Out-Host;
 
-
       #############################
       #         Compress          #
       #############################
@@ -239,7 +230,6 @@ jobs:
         run: >
           mkdir Release;
           Compress-Archive -Path ${{ github.workspace }}/build/* -DestinationPath ${{ github.workspace }}/Release/YARG_${{ env.versionName }}-Windows-x64.zip;
-
 
       #############################
       #          Upload           #
@@ -251,5 +241,5 @@ jobs:
           name: YARG (${{ env.versionName }}) - ${{ env.platform }}
           path: Release/*
 
-    outputs: 
+    outputs:
       artifactId: ${{ steps.artifacts.outputs.artifact-id }}

--- a/.github/workflows/cache-unity-windows.yml
+++ b/.github/workflows/cache-unity-windows.yml
@@ -1,15 +1,17 @@
-name: 📦 Cache Unity 2021.3.21f1 for Windows
+name: 📦 Cache Unity for Windows
 
 on:
   workflow_dispatch:
 
 env:
-  unityVersion: "2021.3.21f1"
-  unityVersionHash: "1b156197d683"
+  unityVersion: "2021.3.36f1"
+  unityVersionHash: "7a0645017be0"
+
+run-name: 📦 Cache Unity ${{ env.unityVersion }} for Windows
 
 jobs:
   cacheUnity:
-    name: Cache Unity 2021.3.21f1 for Windows
+    name: Cache Unity ${{ env.unityVersion }} for Windows
     runs-on: windows-2019
     timeout-minutes: 90
 
@@ -17,7 +19,7 @@ jobs:
       - name: "Get Unity Editor + Windows IL2CPP builder (${{ env.unityVersion }}) pre-installed from cache"
         id: unity-install
         uses: actions/cache@v3.2.2
-        with: 
+        with:
           path: ${{ runner.temp }}/Unity
           key: Windows_Unity-${{ env.unityVersion }}
 

--- a/.github/workflows/get-activation-file.yml
+++ b/.github/workflows/get-activation-file.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
 
 env:
-  unityVersion: "2021.3.21f1"
-  unityVersionHash: "1b156197d683"
+  unityVersion: "2021.3.36f1"
+  unityVersionHash: "7a0645017be0"
 
 jobs:
   windows-requestActivationFile:
@@ -17,7 +17,7 @@ jobs:
       - name: "Get Unity Editor + Windows IL2CPP builder (${{ env.unityVersion }}) pre-installed from cache"
         id: unity-install
         uses: actions/cache@v3.2.2
-        with: 
+        with:
           path: ${{ runner.temp }}/Unity
           key: Windows_Unity-${{ env.unityVersion }}
 
@@ -55,7 +55,6 @@ jobs:
     timeout-minutes: 90
 
     steps:
-
       #############################
       #       Install Unity       #
       #############################
@@ -108,7 +107,7 @@ jobs:
         run: |
           mkdir ${{ runner.temp }}/UnityInstall &&
           curl -L -o "${{ runner.temp }}/UnityInstall/UnitySetup-Editor.pkg" https://download.unity3d.com/download_unity/${{ env.unityVersionHash }}/MacEditorInstaller/Unity-${{ env.unityVersion }}.pkg &&
-          curl -L -o "${{ runner.temp }}/UnityInstall/UnitySetup-Mac-IL2CPP-Support.pkg" https://download.unity3d.com/download_unity/${{ env.unityVersionHash }}/MacEditorTargetInstaller/UnitySetup-Mac-IL2CPP-Support-for-Editor-${{ env.unityVersion }}.pkg        
+          curl -L -o "${{ runner.temp }}/UnityInstall/UnitySetup-Mac-IL2CPP-Support.pkg" https://download.unity3d.com/download_unity/${{ env.unityVersionHash }}/MacEditorTargetInstaller/UnitySetup-Mac-IL2CPP-Support-for-Editor-${{ env.unityVersion }}.pkg
 
       - name: "[Install] Install Unity Editor + Mac IL2CPP builder"
         run: |


### PR DESCRIPTION
> Note: Please only merge this when `dev` branch on main YARG repo is on the new version.

**Summary:**

This updates the Unity version on the builders to `2021.3.36f1` (7a0645017be0)
Direct download links found [here](https://unity.com/releases/editor/whats-new/2021.3.36)

**Links used:**

[Unity Editor - Windows](https://download.unity3d.com/download_unity/7a0645017be0/Windows64EditorInstaller/UnitySetup64-2021.3.36f1.exe)
[Windows IL2CPP support](https://download.unity3d.com/download_unity/7a0645017be0/TargetSupportInstaller/UnitySetup-Windows-IL2CPP-Support-for-Editor-2021.3.36f1.exe)

[Unity Editor - Linux](https://download.unity3d.com/download_unity/7a0645017be0/MacEditorInstaller/Unity-2021.3.36f1.pkg)
[Linux IL2CPP support](https://download.unity3d.com/download_unity/7a0645017be0/LinuxEditorTargetInstaller/UnitySetup-Linux-IL2CPP-Support-for-Editor-2021.3.36f1.tar.xz)

[Unity Editor - Mac](https://download.unity3d.com/download_unity/7a0645017be0/LinuxEditorInstaller/Unity-2021.3.36f1.tar.xz)
[Mac IL2CPP support](https://download.unity3d.com/download_unity/7a0645017be0/MacEditorTargetInstaller/UnitySetup-Mac-IL2CPP-Support-for-Editor-2021.3.36f1.pkg)

**Build tests:**
https://github.com/YARC-Official/YARG-BleedingEdge/actions/runs/8197438423